### PR TITLE
fix heap corruption in convert_string_for_dapi

### DIFF
--- a/src/charset.c
+++ b/src/charset.c
@@ -96,7 +96,7 @@ char* convert_string_for_dapi(char* in, size_t inlen) {
 
 	wbytes = MultiByteToWideChar(CP_ACP, 0, in, inlen, NULL, 0) * sizeof(wchar_t);
 
-	wout = malloc(wbytes);
+	wout = malloc(wbytes + sizeof(wchar_t));
 	len  = wbytes / sizeof(wchar_t);
 
 	memset(wout, 0, wbytes);


### PR DESCRIPTION
One line fix for heap corruption 
```c
wout = malloc(wbytes + sizeof(wchar_t));
```
Allocates one extra char for null terminator so `wout[len] = 0;` later doesn't write past the end of the buffer.

Crash behavior was discovered while implementing dectalkmini into an application. It would crash after a few speaks so I hooked it up to a debugger and traced it to this function.